### PR TITLE
chore: update solarized-theme dependency to 2.1.0

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ This is an Emacs port of [[https://github.com/cocopon/iceberg.vim][iceberg.vim]]
 * Requirements
 
 - Emacs 28.1 or later
-- [[https://github.com/bbatsov/solarized-emacs][solarized-theme]] 1.3 or later
+- [[https://github.com/bbatsov/solarized-emacs][solarized-theme]] 2.1.0 or later
 
 * Installation
 

--- a/iceberg-theme.el
+++ b/iceberg-theme.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.0.1
 ;; Keywords: convenience
-;; Package-Requires: ((emacs "28.1") (solarized-theme "1.3"))
+;; Package-Requires: ((emacs "28.1") (solarized-theme "2.1.0"))
 ;; URL: https://github.com/conao3/iceberg-theme.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Summary

Modernizes the project's dependencies to their latest versions.

- Bumped `solarized-theme` from `1.3` to `2.1.0` (latest MELPA Stable) in the `Package-Requires` header of `iceberg-theme.el` — a major version bump (1.x → 2.x).
- Updated the `solarized-theme` requirement note in `README.org` to match.

The major `solarized-theme` upgrade required no code changes: the `solarized-create-theme-file-with-palette` API used by `iceberg-theme-create-theme-file` remains compatible.

### Notes

- The Cask `development` dependencies (`cort`, `go-mode`, `haskell-mode`, `rust-mode`, `php-mode`, `web-mode`, `markdown-mode`) are unpinned and always resolve to the latest MELPA versions, so there was nothing to bump. Cask has no lockfile to update.
- No major upgrades were deferred.

## Test plan

- [x] `cask install` resolves `solarized-theme 2.1.0`
- [x] `make test` passes (byte-compile clean + cort test run) on Emacs 29.3
- [x] Runtime smoke test: `iceberg-theme-create-theme-file` + `load-theme 'solarized-iceberg-dark` succeeds with solarized-theme 2.1.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7uqqTHQ7wGKLUSvar5wqK)_